### PR TITLE
Basic認証を導入

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,15 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
+
+
+  private
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 
   protected
 


### PR DESCRIPTION
# WHAT
- HTTP通信の規格に備え付けられている、ユーザー認証の仕組みであるBasic認証を用いてwebアプリケーションへの利用を制限する

# WHY
- heroku上へ公開しているので、誤って接続した方へ誤解を招かないようにパスワードを設定する
