### PR TITLE
詳細表示画面の商品説明の修正

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -42,7 +42,7 @@
     <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>


### PR DESCRIPTION
# WHAT
- 商品詳細画面において商品説明が表示されていなかった事の修正

# WHY
- 商品の説明の入力を出品時に入力しているが、それが商品の詳細に反映されていない為